### PR TITLE
updated suseviclient to support ESX 5.5 and 6.0

### DIFF
--- a/suseviclient
+++ b/suseviclient
@@ -438,6 +438,10 @@ register_vm () {
         virtualHWversion="8"
     elif [[ $esxiversion =~ 5\.1\.? ]]; then
         virtualHWversion="9"
+    elif [[ $esxiversion =~ 5\.5\.? ]]; then
+        virtualHWversion="10"
+    elif [[ $esxiversion =~ 6\.0\.? ]]; then
+        virtualHWversion="11"
     else
         echo "Can't detect ESXi version"; cleanup
     fi


### PR DESCRIPTION
- register_vm() was updated to handle recent virtualHWversion's, see
  http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2007240
